### PR TITLE
Fix compilation on systems using unsigned chars by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,9 @@ disable_gnu_warning("class-memaccess")
 # fatal warnings
 enable_gnu_warning("error=return-type")
 
+# explicit signed char, so that resources.cc compiles on all systems
+add_definitions("-fsigned-char")
+
 if(ADLplug_RT_CHECKER)
   add_definitions("-DADLplug_RT_CHECKER=1")
   set(ADLplug_RT_CHECKER_LINK_FLAGS "-Wl,--wrap=malloc -Wl,--wrap=realloc -Wl,--wrap=free -Wl,--wrap=memalign")


### PR DESCRIPTION
Hello,

Here is a small fix I had to perform in order to compile on Raspberry Pi (v4, using an image based on Debian 10 Buster from the Zynthian project http://zynthian.org/ ).  Because it appears that the `char` type is not standard and varies between platforms, an error was raised during the compilation of `resources.cc`.

With this fix everything appears functional -- and on a side note I do not think it would require much work to fully integrate this wonderful wrapper in Zynthian, e.g. the possibility to switch banks and set parts from LV2 parameters.