### PR TITLE
Add stdexcept include to fix build on latest gcc

### DIFF
--- a/sources/opl3/adl/player.cc
+++ b/sources/opl3/adl/player.cc
@@ -3,6 +3,8 @@
 //    (See accompanying file LICENSE or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
+#include <stdexcept>
+
 #include "player.h"
 
 void Player::init(unsigned sample_rate)

--- a/sources/opn2/adl/player.cc
+++ b/sources/opn2/adl/player.cc
@@ -3,6 +3,8 @@
 //    (See accompanying file LICENSE or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
+#include <stdexcept>
+
 #include "player.h"
 
 void Player::init(unsigned sample_rate)


### PR DESCRIPTION
These files `call std::runtime_error()` which is defined in `stdexcept`.