### PR TITLE
Prefer `-pthread` flag for pthread

### DIFF
--- a/cmake/LinkHelpers.cmake
+++ b/cmake/LinkHelpers.cmake
@@ -27,6 +27,7 @@ macro(target_link_static_threads TARGET)
     # use a statically link winpthread
     target_link_libraries("${TARGET}" PRIVATE "-Wl,-Bstatic,--whole-archive -lwinpthread -Wl,--no-whole-archive,-Bdynamic")
   else()
+    set(THREADS_PREFER_PTHREAD_FLAG TRUE)
     find_package(Threads REQUIRED)
     target_link_libraries("${TARGET}" PRIVATE ${CMAKE_THREAD_LIBS_INIT})
   endif()


### PR DESCRIPTION
According to gcc doc, `-pthread` flag will link the program against libraries like libatomic on demand, which is the expected usage of pthread. Using `-lpthread` in CFLAGS and LDFLAGS causes absense of these libraries, thus failing to build on architectures which needs soft atomic operation implementation.

Reference: [GCC doc](https://gcc.gnu.org/onlinedocs/gcc/Preprocessor-Options.html#Preprocessor-Options), [Stack Overflow](https://stackoverflow.com/questions/23250863/difference-between-pthread-and-lpthread-while-compiling)